### PR TITLE
Fix vector TOML template sorting

### DIFF
--- a/templates/vector.toml.j2
+++ b/templates/vector.toml.j2
@@ -7,11 +7,11 @@ data_dir = "/var/lib/vector"
     "sinks": (sinks | default({}))
 } %}
 
-{% for name, cat in loop_helper.items() | sort(attribute='0') %}
-{% for key, value in cat.items() | sort(attribute='0') %}
+{% for name, cat in loop_helper | dictsort %}
+{% for key, value in cat | dictsort %}
 [{{ name }}.{{ key }}]
   {% if value %}
-  {%- for skey, svalue in value.items() | sort(attribute='0') %}
+  {%- for skey, svalue in value | dictsort %}
 {%- if svalue is string %}
   {{ skey }} = "{{ svalue }}"
 {% else %}


### PR DESCRIPTION
## Summary
- update vector.toml.j2 to sort dictionaries correctly

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6872c852c6c4832f8d63f0b6b065a6e8