### PR TITLE
Fix grammar in README and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ansible-vector
 
-This is a ansible role to set up [vector](https://vector.dev) on debian and redhat based systems.
+This is an Ansible role to set up [vector](https://vector.dev) on Debian and Red Hat-based systems.
 It translates the YAML configuration to TOML, so any configuration is possible.
 
 Currently only amd64, arch64, arch7 through deb and rpm packages are supported.
@@ -21,7 +21,7 @@ Currently only amd64, arch64, arch7 through deb and rpm packages are supported.
 | transforms               | no       | false                   | shape your data as it moves through your Vector topology [link](https://vector.dev/docs/reference/configuration/transforms/)
 | sinks                    | yes      | false                   | deliver your observability data to a variety of destinations [link](https://vector.dev/docs/reference/configuration/sinks/)
 
-## Example for configuration with ansible
+## Example configuration with Ansible
 ```yaml
 sources:
   journald:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ authors:
   - Daniel Uhlmann <daniel.uhlmann@telekom.de>
   - Christopher Grau <c.grau@telekom.de>
 description: >-
-  This is a ansible collection to set up [vector](https://vector.dev) on debian and redhat based systems.
+  This is an Ansible collection to set up [vector](https://vector.dev) on Debian and Red Hat-based systems.
   It translates the YAML configuration to TOML, so any configuration is possible.
 license_file: LICENSE
 tags:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,7 +11,7 @@ galaxy_info:
     - Daniel Uhlmann <daniel.uhlmann@telekom.de>
     - Christopher Grau <c.grau@telekom.de>
   description: >-
-    This is a ansible collection to set up [vector](https://vector.dev) on debian and redhat based systems.
+    This is an Ansible collection to set up [vector](https://vector.dev) on Debian and Red Hat-based systems.
     It translates the YAML configuration to TOML, so any configuration is possible.
   license_file: LICENSE
   tags:


### PR DESCRIPTION
## Summary
- correct indefinite article usage for Ansible in README, galaxy.yml, and meta/main.yml
- improve capitalization in documentation

## Testing
- `ansible-lint` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6872cc32d61c832fbd01f6e2b747ec1b